### PR TITLE
Fix Promise API usage

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@
 var fs = require('fs')
 var list = require('./list')
 
-list().done(function (transforms) {
+list().then(function (transforms) {
   var output = JSON.stringify(transforms, null, 2)
   fs.writeFileSync('list-of-jstransformers.json', output)
 })

--- a/list.js
+++ b/list.js
@@ -8,7 +8,7 @@ var ignore = [
 ]
 
 module.exports = function () {
-  return Promise.resolve(npmKeyword.names('jstransformer')).then(function (data) {
+  return npmKeyword.names('jstransformer').then(function (data) {
     // Filter out all the none-Transforms
     var jstransformers = data.filter(function (name) {
       return name.indexOf('jstransformer-') === 0 &&


### PR DESCRIPTION
`.done()` is not part of the standard Promise API, so removing the "promise" dependency means switching to `.then`, which is technically slightly different.
https://www.npmjs.com/package/promise#promisedoneonfulfilled-onrejected

Assuming you're using a new-enough version of node.js to run the build script, promise rejections will still be logged to the console in a useful way.  In old versions of node, promise rejections might be swallowed and hidden.